### PR TITLE
Update book-processor.js

### DIFF
--- a/dev/books/book-processor.js
+++ b/dev/books/book-processor.js
@@ -156,7 +156,7 @@ function writeBookFiles(book, children, rootFolder, tmplStr, nodeList) {
         );
         //if (!isNodeEmpty(node)) // not write empty files
         genericWriteFile(`${rootFolder}/${getNodeFileName(node)}`, contentDiv, tmplStr,
-            { title: `${node.header.text()} < ${book.name}`, desc: `${book.name} - ${book.author}`, folder: book.folder })
+            { title: `${node.header.text()} - ${book.name}`, desc: `${book.name} - ${book.author}`, folder: book.folder })
         writeBookFiles(book, node.children, rootFolder, tmplStr, nodeList);
     });
 }


### PR DESCRIPTION
Less than sign character `<` may be problematic when rendering tDOM. Replaced it with a simple dash `-`.